### PR TITLE
USNG-3 Fix bug when no east or north

### DIFF
--- a/usng.js
+++ b/usng.js
@@ -850,7 +850,9 @@
                 
                 if ( eastingArray[i].indexOf(sq1) != -1) {
                     easting = i*100000;
-                    easting = easting + Number(east)*Math.pow(10,5-east.length);
+                    if (east) {
+                        easting = easting + Number(east)*Math.pow(10,5-east.length);
+                    }
                     break;
                 }
             }
@@ -864,7 +866,10 @@
             while (northing < zoneBase["CDEFGHJKLMNPQRSTUVWX".indexOf(letter)]) {
                 northing = northing + 2000000;
                 }
-            var northing = northing+Number(north)*Math.pow(10,5-north.length);
+
+            if (north) {
+                northing = northing+Number(north)*Math.pow(10,5-north.length);
+            }
             ret.N = parseInt(northing);
             ret.E = parseInt(easting);
             ret.zone = zone;


### PR DESCRIPTION
In the case when there is no "east" or "north" value passed to
USNGtoUTM, eg the USNG string is DDL or DDL LL, an error would occur
when trying to read the 'length' property of 'east' or 'north' which is
null.
