### PR TITLE
USNG-3 Fix intermittent northing issue

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1614,6 +1614,19 @@ describe('Convert Lat/Lon to UTM', function(){
         chai.assert.equal(true, essentiallyEqual(east, result.east, 0.0001));
         chai.assert.equal(true, essentiallyEqual(west, result.west, 0.0001));
       });
+      it('should return 32 -102 24 -96', function(){
+        var usng = "14R";
+        var north = 32;
+        var west = -102;
+        var east = -96;
+        var south = 24;
+        var result = converter.USNGtoLL(usng, false);
+        console.log(result.north, result.south, result.east, result.west);
+        chai.assert.equal(true, essentiallyEqual(north, result.north, 0.0001));
+        chai.assert.equal(true, essentiallyEqual(south, result.south, 0.0001));
+        chai.assert.equal(true, essentiallyEqual(east, result.east, 0.0001));
+        chai.assert.equal(true, essentiallyEqual(west, result.west, 0.0001));
+      });
     });
   });
 });

--- a/usng.js
+++ b/usng.js
@@ -881,7 +881,8 @@
             }
 
             var northing = 0;
-
+            
+            if (sq2) {
             // if zone number is even, use northingArrayEven, if odd, use northingArrayOdd
             // similar to finding easting, the index of sq2 corresponds with the base easting
             if (zone%2 == 0) {
@@ -892,14 +893,20 @@
 
             // we can exploit the repeating behavior of northing to find what the total northing should be
             // iterate through the horizontal zone bands until our northing is greater than the zoneBase of our zone
-            while (northing < zoneBase["CDEFGHJKLMNPQRSTUVWX".indexOf(letter)]) {
-                northing = northing + 2000000;
+            
+                while (northing < zoneBase["CDEFGHJKLMNPQRSTUVWX".indexOf(letter)]) {
+                    northing = northing + 2000000;
+                    }
+
+                if (north) {
+
+                    // add the north parameter to get the total northing
+                    northing = northing+Number(north)*Math.pow(10,5-north.length);
                 }
-
-            if (north) {
-
-                // add the north parameter to get the total northing
-                northing = northing+Number(north)*Math.pow(10,5-north.length);
+            }
+            else {
+                // add approximately half of the height of one large region to ensure we're in the right zone
+                northing = zoneBase["CDEFGHJKLMNPQRSTUVWX".indexOf(letter)]+499600;
             }
 
             // set return object


### PR DESCRIPTION
Northing was calculated incorrectly for certain bounding boxes.
In alternating horizontal bands, when drawing the largest zone, e.g,
12R, 13R, 17M, etc, the drawing would jump up a region. I.e, 12R would
appear where 12S is. 12S would still be in the correct place.
This seems to have been an edge case condition with the largest regions
having northings ignored. Now, when a region is the largest, it has approx.
500k added to its northing to estimate the middle and more accurately
represent its position.
